### PR TITLE
Fixed race condition where init would be called before extension was registered.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2512,15 +2512,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2530,6 +2521,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3834,8 +3834,9 @@
       "dev": true
     },
     "penpal": {
-      "version": "https://registry.npmjs.org/penpal/-/penpal-2.5.1.tgz",
-      "integrity": "sha1-vfaA5pqCO73x1cPPMpiMb4SE5BE="
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/penpal/-/penpal-2.7.2.tgz",
+      "integrity": "sha512-wiD5bREvHsPxOJTRXBLpt4h7QfLjNtWXL2me5MopsYXQ9tIOM8ehffDIgrNkMBJgtjLlLdrHw4LfLnij5q2R9Q=="
     },
     "pify": {
       "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -4533,14 +4534,6 @@
         "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
       }
     },
-    "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-      }
-    },
     "string-width": {
       "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
@@ -4559,6 +4552,14 @@
         "define-properties": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
         "es-abstract": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.0.tgz",
         "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+      }
+    },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "domready": "^1.0.8",
     "layout-observer": "^1.1.1",
     "once": "^1.4.0",
-    "penpal": "2.5.1",
+    "penpal": "^2.7.2",
     "promise-polyfill": "^6.0.2"
   },
   "devDependencies": {

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -107,7 +107,7 @@ describe('parent', () => {
     });
   });
 
-  it('rejects load promise if extension view has not registered init function', done => {
+  it('times out if extension view doesn\'t register with bridge', done => {
     bridge = loadIframe({
       url: `http://${location.hostname}:9800/unregisteredInit.html`
     });
@@ -115,8 +115,7 @@ describe('parent', () => {
     bridge.promise.then(
       () => {},
       error => {
-        expect(error).toBe('Initialization failed: Error: Unable to call init on the extension. ' +
-          'The extension must register a init function using extensionBridge.register().');
+        expect(error).toBe('renderTimeout');
         done();
       }
     );
@@ -130,7 +129,7 @@ describe('parent', () => {
     bridge.promise.then(
       () => {},
       error => {
-        expect(error).toBe('Initialization failed: Error: bad things');
+        expect(error).toBe('Extension initialization failed: Error: bad things');
         done();
       }
     );


### PR DESCRIPTION
This fixes a race condition where the parent tries to call the child's `init` method before the child has called `extensionBridge.register`, resulting in a broken functionality. Now, the parent waits until the child has called `extensionBridge.register` before attempting to call `init` on the child.

This race condition was exhibited often with later versions of Penpal. Now that the race condition is resolved, I've updated to the latest version of Penpal.